### PR TITLE
Chdir bugfix

### DIFF
--- a/git-pair
+++ b/git-pair
@@ -51,7 +51,9 @@ end
 ## End of configuration
 #######################################################################
 
+cur_dir = Dir.pwd
 config = get_pairs_config
+Dir.chdir cur_dir # change back to initial dir in case get_pairs_config had to walk up to find .pairs
 authors = ARGV.map do |initials|
   if full_name = config['pairs'][initials.downcase]
     full_name


### PR DESCRIPTION
If the .pairs file is put in the home directory, when **git-pair** was run it would Dir.chdir ".." to find .pairs but not move back into the project.
