### PR TITLE
Setting and email address without a prefixed defined wasn't working correctly.

### DIFF
--- a/bin/git-pair
+++ b/bin/git-pair
@@ -87,12 +87,8 @@ if authors.any?
   else
     authors = names[0..-2].join(", ") + " & " + names.last
   end
-  email = 
-    if email_prefix = config['email']['prefix']
-      "#{([email_prefix] + emails).join('+')}@#{config['email']['domain']}"
-    else
-      config['email']
-    end
+
+  email = "#{([config['email']['prefix']] + emails).compact.join('+')}@#{config['email']['domain']}"
   system(%Q{git config #{global_config_string} user.name "#{authors}"})
   system(%Q{git config #{global_config_string} user.email "#{email}"})
 else


### PR DESCRIPTION
Even though the logic was  sorta there, this wasn't working right. Leaving the prefix out of the .pairs file will now just prepend nothing to the email address.
