### PR TITLE
Work in any subdirectory of a git repository

### DIFF
--- a/bin/git-pair
+++ b/bin/git-pair
@@ -14,7 +14,8 @@
 
 require 'yaml'
 
-unless File.exists?(".git")
+git_dir = `git rev-parse --git-dir`.chomp
+unless File.exists?(git_dir)
   puts "This doesn't look like a git repository."
   exit 1
 end
@@ -102,7 +103,7 @@ else
 end
 
 global_name_setting = `git config --global --get-regexp '^user\.name'`
-local_name_setting = `git config -f .git/config --get-regexp '^user\.name'`
+local_name_setting = `git config -f #{git_dir}/config --get-regexp '^user\.name'`
 if global_name_setting.length > 0 && local_name_setting.length > 0
   puts "NOTE: Overriding global user.name setting with local."
 end
@@ -111,7 +112,7 @@ puts "local:  #{local_name_setting}"  if local_name_setting.length > 0
 
 
 global_email_setting = `git config --global --get-regexp '^user\.email'`
-local_email_setting = `git config -f .git/config --get-regexp '^user\.email'`
+local_email_setting = `git config -f #{git_dir}/config --get-regexp '^user\.email'`
 if global_email_setting.length > 0 && local_email_setting.length > 0
   puts "NOTE: Overriding global user.email setting with local."
 end


### PR DESCRIPTION
This makes it so you can use "git pair" in any subdirectory of a git project, not just the top-level directory.
