### PR TITLE
Adding Oxford commas where appropriate

### DIFF
--- a/bin/git-pair
+++ b/bin/git-pair
@@ -142,7 +142,8 @@ global = " --global" if options[:global] or config["global"]
 
 if initials.any?
   author_names, email_ids = extract_author_names_and_email_ids_from_config(config, initials)
-  authors = [author_names[0..-2].join(", "), author_names.last].reject(&:empty?).join(" and ")
+  oxford_comma = (author_names.length > 2) ? "," : ""
+  authors = [author_names[0..-2].join(", ") + oxford_comma, author_names.last].reject(&:empty?).join(" and ")
   git_config = {:name => authors,  :initials => initials.join(" ")}
   git_config[:email] = build_email(email_ids, config["email"]) unless no_email(config)
   set_git_config global,  git_config

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -146,7 +146,7 @@ describe "CLI" do
 
       it "can set n users as pair" do
         result = run "git pair ab bc cd"
-        expect_config result, "Aa Bb, Bb Cc and Cc Dd", "ab bc cd", "the-pair+aa+bb+cc@the-host.com"
+        expect_config result, "Aa Bb, Bb Cc, and Cc Dd", "ab bc cd", "the-pair+aa+bb+cc@the-host.com"
       end
 
       it "can set a user with apostrophes as pair" do


### PR DESCRIPTION
When a "pair" consists of three or more authors, we should be using the Oxford comma (see Strunk & White's [The Elements of Style](http://books.google.com/books?id=pYYUAQAAIAAJ&dq=isbn%3A1594200696&q=%22In+a+series+of+three+or+more%22#search_anchor)).