### PR TITLE
Add current directory to load path of git-pair

### DIFF
--- a/bin/git-pair
+++ b/bin/git-pair
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+$:.unshift File.expand_path('..', __FILE__)
 require 'yaml'
 require 'optparse'
 require 'pivotal_git_scripts/git_pair'


### PR DESCRIPTION
git-pair is unable to find 'pivotal_git_scripts/git_pair' without munging $LOAD_PATH.
