### PR TITLE
Fixes LOAD_PATH issue when using ruby >= v1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These scripts are helpers for managing developer workflow when using git repos h
 
 ## System Wide Installation
 
-    $ cd /usr/local/bin && curl -L http://github.com/pivotal/git_scripts/tarball/master | gunzip | tar xvf - --strip=2
+    $ cd /usr/local/bin && curl -L http://github.com/pivotal/git_scripts/tarball/master | gunzip | tar xvf - --include=*bin --include=*lib --strip=2
 
 ## git-about
 

--- a/bin/git-pair
+++ b/bin/git-pair
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'yaml'
 require 'optparse'
-require 'pivotal_git_scripts/git_pair'
+require File.expand_path(File.join(File.dirname(__FILE__),'pivotal_git_scripts/git_pair'))
 
 PivotalGitScripts::GitPair.main(ARGV)


### PR DESCRIPTION
after ruby 1.9.2 The default LOAD_PATH no longer includes '.' so we are now requiring the specific file using an absolute reference.

Also fixes installer to only copy over files used in the implementation.
