### PR TITLE
Add ability to use a custom email address per user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pivotal_git_scripts (1.2.0)
+    pivotal_git_scripts (1.3.0)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/pivotal_git_scripts/version.rb
+++ b/lib/pivotal_git_scripts/version.rb
@@ -1,3 +1,3 @@
 module PivotalGitScripts
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -291,6 +291,9 @@ describe "CLI" do
           email:
             prefix: the-pair
             domain: the-host.com
+
+          email_addresses:
+            bc: test@other-host.com
       YAML
     end
 
@@ -375,6 +378,20 @@ describe "CLI" do
           git_pair_commit
 
           %w(abb@the-host.com cdd@the-host.com).should include(committer_email_of_last_commit)
+        end
+      end
+
+      context 'when one of the pair has a custom email address' do
+        before do
+          run 'git pair ab bc'
+        end
+
+        it 'uses that email address' do
+          emails = 6.times.map do
+            git_pair_commit
+            author_email_of_last_commit
+          end.uniq
+          emails.should =~ ['abb@the-host.com', 'test@other-host.com']
         end
       end
     end


### PR DESCRIPTION
this just comes up so much when pairing with folks from different orgs

used the same format in the config as git duet because copy and paste is the best
