### PR TITLE
Support `.pairs` in the user's HOME directory, as advertised.

### DIFF
--- a/lib/pivotal_git_scripts/git_pair.rb
+++ b/lib/pivotal_git_scripts/git_pair.rb
@@ -135,6 +135,8 @@ BANNER
           directory = File.absolute_path(File.join(directory, ".."))
           candidate_directories << directory
         end
+        home = File.absolute_path(ENV["HOME"])
+        candidate_directories << home unless candidate_directories.include? home
 
         pairs_file_path = candidate_directories.
           map { |d| File.join(d, ".pairs") }.


### PR DESCRIPTION
The README file states that a `.pairs` file may be "in project root or your home folder." This isn't true unless the working directory is under the user's home directory.

This PR contains two commits: one to slightly clean up the directory-search logic; and then a second to implement the addition of the user's home directory to the end of the search path.
