### PR TITLE
Add instructions for different email domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,19 @@ Options are:
 
 Makes a git commit as normal, but chooses one of the pair members randomly to get credit for the commit on github (by setting the author email to that member's email address). The author name on the commit will list all members of the pair, as usual.
 
+If pair members have email addresses on different domains, you can specify them separately in your `.pairs` file.
+
+    pairs:
+      jd: Jane Doe
+      fb: Frances Bar
+    email_addresses:
+      jd: jane@awesome.local
+      fb: frances@foo.bar
+
 ### Using git-pair-commit in RubyMine
 RubyMine already supports pointing at a custom location for your git executable in the Preferences -> Version Control -> Git
 ![screen shot 2014-03-11 at 12 49 02 pm](https://f.cloud.github.com/assets/163532/2390097/49c3023e-a956-11e3-8aeb-dcba1a814309.png)
-The trick then is that `pair-commit` doesn't encompass all git functionality, so you can't just point RubyMine directly at it, you need something in the middle that will use `pair-commit` if the first arg is `commit`, otherwise just pass through. Here's a ruby script to do just that: 
+The trick then is that `pair-commit` doesn't encompass all git functionality, so you can't just point RubyMine directly at it, you need something in the middle that will use `pair-commit` if the first arg is `commit`, otherwise just pass through. Here's a ruby script to do just that:
 ```ruby
 #!/usr/bin/env ruby
 
@@ -67,7 +76,7 @@ end
 
 exit exit_code
 ```
-Make sure it's executable. 
+Make sure it's executable.
 
 ## git-project
 


### PR DESCRIPTION
I spent a few days searching for solutions to this problem before seeing that someone already solved it! I added a section to the instructions explaining how to modify your .pairs file for different email domains. This is really useful to my fellow code schools students and I. The Atom editor apparently automatically removed trailing whitespace on a couple paragraphs as well.