### PR TITLE
Change author of last commit with --amend-author

### DIFF
--- a/spec/git_pair_spec.rb
+++ b/spec/git_pair_spec.rb
@@ -49,4 +49,22 @@ describe PivotalGitScripts::GitPair::Runner do
       }.to raise_error(PivotalGitScripts::GitPair::GitPairException)
     end
   end
+
+  describe 'amends authors' do
+    it 'chooses last commit to amend author by default' do
+      config = {
+        'pairs' => {
+          'aa' => 'An Aardvark; aardvark',
+          'tt' => 'The Turtle; turtle'
+        },
+        'email' => {
+          'prefix' => 'pair',
+          'domain' => 'pivotal.io'
+        }
+      }
+
+      expect(runner).to receive(:system).with("git commit --amend --author=\"An Aardvark and The Turtle <pair+aardvark+turtle@pivotal.io>\"")
+      runner.amend_author_from_last_commit(config, ['aa', 'tt'])
+    end
+  end
 end


### PR DESCRIPTION
Hi,

I often find myself forgetting to change the git pair when making commits on a new workstation.  It would be nice to be able to easily change the author pair of the last commit.  

This allows you to amend the last commit by using the same initials used to set `git pair`.

Thanks,

Sai To