### PR TITLE
Link public ssh key if available

### DIFF
--- a/bin/git-project
+++ b/bin/git-project
@@ -24,6 +24,10 @@ Dir.chdir(File.expand_path('~/.ssh')) do
   possible_id_files.each do |id_file|
     if File.exists?(id_file)
       `ln -sf #{id_file} id_github_current`
+      pub_file = id_file + ".pub"
+      if File.exists?(pub_file)
+          `ln -sf #{pub_file} id_github_current.pub`
+      end
       puts "Now using key #{id_file}"
       check_ssh_config
       exit 0

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -80,6 +80,34 @@ describe "CLI" do
     end
   end
 
+  describe "project" do
+    before do
+      run "mkdir home/.ssh"
+      run "touch home/.ssh/config"
+      File.open("home/.ssh/config", "w") do |f|
+        f.write <<END
+Host github.com
+  User git
+  IdentityFile id_github_current
+END
+      end
+    end
+
+    it "links id_github_current" do
+      run "touch home/.ssh/id_github_bar"
+      run "git project bar"
+      run("git about").should =~ /GitHub project:\s+bar/
+    end
+
+    it "links id_github_current.pub" do
+      run "touch home/.ssh/id_github_lala"
+      run "touch home/.ssh/id_github_lala.pub"
+      run "git project lala"
+      expect(File.exists?("home/.ssh/id_github_current.pub")).to eq(true)
+      expect(File.readlink("home/.ssh/id_github_current.pub")).to eq("id_github_lala.pub")
+    end
+  end
+
   describe "pair" do
     def expect_config(result, name, initials, email, options={})
       global = "cd /tmp && " if options[:global]


### PR DESCRIPTION
When running `git project myname`, it will attempt to link `.ssh/id_github_current.pub` to `.ssh/id_github_myname.pub`. This is necessary for some ssh agents to save keys.

In particular, gnome 3's password keeper seems to have trouble remembering ssh keys if the pub file isn't present.

I also added specs for `git project`.
